### PR TITLE
fix: add new rtes tech in reeds default .json file

### DIFF
--- a/src/r2x_reeds/config/defaults.json
+++ b/src/r2x_reeds/config/defaults.json
@@ -117,7 +117,8 @@
       "prefixes": [
         "geothermal",
         "geohydro",
-        "egs"
+        "egs",
+        "rtes"
       ],
       "exact": []
     },


### PR DESCRIPTION
This is a small change on the defaults.json, for the geothermal key. New tech added related to RTES (Reservoir Thermal Energy Storage)